### PR TITLE
Fix repo update logic and typo

### DIFF
--- a/auth-service/internal/auth/errors/errors.go
+++ b/auth-service/internal/auth/errors/errors.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	ErrInvalidArgument    = errors.New("invalid argument")
-	ErrInternal           = errors.New("internal errors")
+	ErrInternal           = errors.New("internal error")
 	ErrNotFound           = errors.New("not found")
 	ErrInvalidCredentials = errors.New("invalid credentials")
 	ErrAlreadyExists      = errors.New("already exists")

--- a/auth-service/internal/repo/postgres/postgres_user_repo.go
+++ b/auth-service/internal/repo/postgres/postgres_user_repo.go
@@ -70,15 +70,12 @@ func (p *PostgresUserRepo) GetUserByUsername(ctx context.Context, username strin
 }
 
 func (p *PostgresUserRepo) UpdateUser(ctx context.Context, user model.User) error {
-	res := p.db.WithContext(ctx).Save(&user)
+	res := p.db.WithContext(ctx).Model(&model.User{}).Where("id = ?", user.ID).Updates(user)
 	if err := res.Error; err != nil {
 		return customErrors.WrapInternal(err, "UpdateUser")
 	}
-	if res.RowsAffected == 0 && user.ID != uuid.Nil {
-		exists := p.db.First(&model.User{}, "id = ?", user.ID).Error
-		if errors.Is(exists, gorm.ErrRecordNotFound) {
-			return customErrors.ErrNotFound
-		}
+	if res.RowsAffected == 0 {
+		return customErrors.ErrNotFound
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- fix typo in `ErrInternal`
- avoid unintended inserts when updating Postgres users

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f51a54958832a8203dd8f9a0a0e7c